### PR TITLE
fix: bug with processing double-dash arguments

### DIFF
--- a/machine.js
+++ b/machine.js
@@ -232,7 +232,7 @@ app.post("/projects/:id", jsonParser, (req, res) => {
           args.push(options[prop]);
         }
       } else if (project.options === "double-dash") {
-        if (!(typeof(options[prop]) === "boolean" && project.boolean === "optional")) {
+        if (typeof(options[prop]) === "boolean" && project.boolean === "optional") {
           args.push("--" + prop);
         } else {
           args.push("--" + prop + "=" + options[prop]);


### PR DESCRIPTION
After introducing boolean arguments, double-dash arguments were not correctly processed (the values were always omitted)